### PR TITLE
compatibility with other assemblers

### DIFF
--- a/R/metagen.R
+++ b/R/metagen.R
@@ -68,7 +68,7 @@ fadat = read.fasta(file = ctg_file)
 
 ctg_name = unlist(lapply(getAnnot(fadat), function(x){strsplit(x," ")[[1]][1]}))
 
-lvec = as.numeric(unlist(lapply(getAnnot(fadat), function(x){strsplit(x," ")[[1]][2]})))
+lvec = as.numeric(unlist(lapply(fadat,length)))
 
 nvec = numeric(ncol(dmat))
 


### PR DESCRIPTION
modified the way lvec is obtained so that obtaining contigs length isn't dependent of the contig header to be able to use assemblies from assemblers other than Ray.